### PR TITLE
fix(whatsapp): correct Evolution API RabbitMQ queue naming convention

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# RabbitMQ Configuration
+RABBITMQ_URI=amqp://guest:guest@localhost:5672/
+RABBITMQ_EXCHANGE=evolution_exchange
+WHATSAPP_INSTANCE=your-whatsapp-instance
+
+# Agent API Configuration
+AGENT_API_URL=http://localhost:8000
+AGENT_API_KEY=your-agent-api-key
+DEFAULT_AGENT_NAME=default
+
+# Evolution Transcript API Configuration
+EVOLUTION_TRANSCRIPT_API=http://localhost:8001/api
+EVOLUTION_TRANSCRIPT_API_KEY=your-evolution-transcript-api-key
+
+# Logging Configuration
+LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -14,12 +14,47 @@ This project implements an AI agent system that can integrate with various commu
 
 ## Configuration
 
-Copy the `.env.example` file (if available) to `.env` and fill in the required configuration values.
+Copy the `.env.example` file to `.env` and fill in the required configuration values:
+
+```bash
+cp .env.example .env
+```
+
+Then edit the `.env` file to set your specific configuration:
+
+```
+# RabbitMQ Configuration
+RABBITMQ_URI=amqp://user:password@localhost:5672/default
+RABBITMQ_EXCHANGE=evolution_exchange
+WHATSAPP_INSTANCE=Personal
+
+# Agent API Configuration
+AGENT_API_URL=http://localhost:8000
+AGENT_API_KEY=your_api_key
+DEFAULT_AGENT_NAME=default
+
+# Evolution Transcript API Configuration
+EVOLUTION_TRANSCRIPT_API=http://localhost:8001/api
+EVOLUTION_TRANSCRIPT_API_KEY=your_api_key
+
+# Logging Configuration
+LOG_LEVEL=DEBUG
+```
+
+### WhatsApp Integration with Evolution API
+
+This project integrates with the Evolution API for WhatsApp messaging. The integration uses RabbitMQ for message queuing. Key configuration parameters:
+
+- `RABBITMQ_URI`: URI for connecting to RabbitMQ (e.g., `amqp://user:password@localhost:5672/default`)
+- `RABBITMQ_EXCHANGE`: Exchange name for RabbitMQ (default: `evolution_exchange`)
+- `WHATSAPP_INSTANCE`: Name of the WhatsApp instance in Evolution API (e.g., `Personal`)
+
+Note: The Evolution API creates RabbitMQ queues with the prefix "evolution." (e.g., "evolution.messages.upsert").
 
 ## Running the Application
 
 ```bash
-python -m src.main
+python -m src.cli.main
 ```
 
 ## Development


### PR DESCRIPTION
## WhatsApp Integration with Evolution API

This PR addresses connectivity issues between the Omni-Hub and Evolution API through RabbitMQ.

## Changes:

- Update queue naming to use "evolution." prefix instead of instance name
- Extract string value from EventType enum when constructing queue names
- Fix connection to RabbitMQ queues to match Evolution API implementation
- Add .env.example file as a template for environment configuration
- Update README.md with detailed instructions for Evolution API integration
- Add complete documentation for .env configuration
- Correct the command to run the application in the README

## Modified files:
- src/channels/whatsapp/evolution_api_client.py
- .env.example
- README.md

## Testing:
The integration has been tested and confirmed working with Evolution API v2.2.3. Messages are successfully received from WhatsApp and processed by the Omni-Hub.